### PR TITLE
Issues with Get-ITGlueConfigurationInterfaces

### DIFF
--- a/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
+++ b/ITGlueAPI/Resources/ConfigurationInterfaces.ps1
@@ -36,12 +36,15 @@ function New-ITGlueConfigurationInterfaces {
 function Get-ITGlueConfigurationInterfaces {
     [CmdletBinding(DefaultParametersetName = 'index')]
     Param (
-        [Parameter(ParameterSetName = 'index')]
+        [Parameter(ParameterSetName = 'index', Mandatory = $true)]
         [Parameter(ParameterSetName = 'show')]
         [Nullable[Int64]]$conf_id = $null,
 
         [Parameter(ParameterSetName = 'index')]
         [Nullable[Int64]]$filter_id = $null,
+
+        [Parameter(ParameterSetName = 'index')]
+        [String]$filter_ip_address = $null,
 
         [Parameter(ParameterSetName = 'index')]
         [ValidateSet('created_at', 'updated-at', `
@@ -54,13 +57,16 @@ function Get-ITGlueConfigurationInterfaces {
         [Parameter(ParameterSetName = 'index')]
         [Nullable[int]]$page_size = $null,
 
-        [Parameter(ParameterSetName = 'show')]
-        [Nullable[Int64]]$id = $null
+        [Parameter(ParameterSetName = 'show', Mandatory = $true)]
+        [Nullable[Int64]]$id
     )
 
-    $resource_uri = ('/configurations/{0}/relationships/configuration_interfaces/{1}' -f $conf_id, $id)
+    $resource_uri = ('/configurations/{0}/relationships/configuration_interfaces/' -f $conf_id)
+
     if (($PsCmdlet.ParameterSetName -eq 'show') -and ($null -eq $conf_id)) {
         $resource_uri = ('/configuration_interfaces/{0}' -f $id)
+    } elseif (($PsCmdlet.ParameterSetName -eq 'show') -and ($null -ne $conf_id)) {
+        $resource_uri = ('/configurations/{0}/relationships/configuration_interfaces/{1}' -f $conf_id, $id)
     }
 
     $body = @{}
@@ -68,6 +74,9 @@ function Get-ITGlueConfigurationInterfaces {
     if ($PSCmdlet.ParameterSetName -eq 'index') {
         if ($filter_id) {
             $body += @{'filter[id]' = $filter_id}
+        }
+        if ($filter_ip_address) {
+            $body += @{'filter[id]' = $filter_id }
         }
         if ($sort) {
             $body += @{'sort' = $sort}


### PR DESCRIPTION
Fix for #105:
Made `$conf_id` mandatory for `index` path.
Made `id` mandatory for `show` path and removed from `index` path.
Added missing filter parameter for ip address.
Changed default paramter set name to `index`.
Changed `$resource_uri` to match index path.